### PR TITLE
'elm make --optimize' fails when 'Debug' lines present

### DIFF
--- a/src/Tree/Extra.elm
+++ b/src/Tree/Extra.elm
@@ -93,9 +93,6 @@ attachSubtreeInOrder bigger targetNode subTree tree =
 
         Just attachmentNode ->
             let
-                _ =
-                    Debug.log "attachmentNode" attachmentNode
-
                 zipper =
                     Zipper.fromTree tree |> setFocus attachmentNode
 


### PR DESCRIPTION
Hey @jxxcarlson,

We've got a project where we're using your extremely helpful package.  In trying to get it built for deployment it's failing due to `elm make --optimize` not liking `Debug.log` statements.

```
-- DEBUG REMNANTS --------------------------------------------------------------

There are uses of the `Debug` module in the following modules:

    Tree.Extra

But the --optimize flag only works if all `Debug` functions are removed!

Note: The issue is that --optimize strips out info needed by `Debug` functions.
Here are two examples:

    (1) It shortens record field names. This makes the generated JavaScript is
    smaller, but `Debug.toString` cannot know the real field names anymore.

    (2) Values like `type Height = Height Float` are unboxed. This reduces
    allocation, but it also means that `Debug.toString` cannot tell if it is
    looking at a `Height` or `Float` value.

There are a few other cases like that, and it will be much worse once we start
inlining code. That optimization could move `Debug.log` and `Debug.todo` calls,
resulting in unpredictable behavior. I hope that clarifies why this restriction
exists!
```

I figured I'd make the change and PR it rather than asking for the you to spend time on it.

Thanks in advance and let me know if there are any problems I'm not seeing.

Also, thanks again for the great work in this lib.